### PR TITLE
Use checked_mul for cartesian_base::size

### DIFF
--- a/include/flux/core/numeric.hpp
+++ b/include/flux/core/numeric.hpp
@@ -171,6 +171,30 @@ inline constexpr auto checked_mul =
   }
 };
 
+namespace detail {
+template<std::signed_integral... Ts>
+inline constexpr auto variadic_checked_mul_impl(Ts... ts);
+
+template<std::signed_integral T1, std::signed_integral T2>
+inline constexpr auto variadic_checked_mul_impl(T1 lhs, T2 rhs) {
+    return checked_mul(lhs, rhs);
+};
+
+template<std::signed_integral T1, std::signed_integral T2, std::signed_integral... Ts>
+inline constexpr auto variadic_checked_mul_impl(T1 lhs, T2 rhs, Ts... ts) {
+    return variadic_checked_mul_impl(
+        variadic_checked_mul_impl<T1, T2>(lhs, rhs), ts...);
+};
+
+}
+
+template<std::signed_integral T1, std::signed_integral T2, std::signed_integral... Ts>
+FLUX_EXPORT
+inline constexpr auto variadic_checked_mul(T1 lhs, T2 rhs, Ts... ts) {
+    return detail::variadic_checked_mul_impl(lhs, rhs, ts...);
+};
+
+
 FLUX_EXPORT
 inline constexpr auto checked_pow =
         []<std::signed_integral T, std::unsigned_integral U>(T base, U exponent,

--- a/include/flux/op/cartesian_base.hpp
+++ b/include/flux/op/cartesian_base.hpp
@@ -231,8 +231,16 @@ public:
         requires (CartesianKind == cartesian_kind::product
                   && (sized_sequence<Bases> && ...))
     {
-        return std::apply([](auto&... base) {
-            return (flux::size(base) * ...);
+        return std::apply(overloaded {
+            [] {
+                return 0;
+            },
+            [](auto& base) {
+                return flux::size(base);
+            },
+            [](auto& base1, auto& base2, auto&... rest) {
+                return num::variadic_checked_mul(flux::size(base1), flux::size(base2), flux::size(rest)...);
+            }
         }, self.bases_);
     }
 

--- a/include/flux/op/requirements.hpp
+++ b/include/flux/op/requirements.hpp
@@ -42,6 +42,13 @@ concept repeated_invocable = repeated_invocable_helper<Func, E, N>::value;
 
 } // namespace detail
 
+namespace detail {
+
+template<typename... Ts> struct overloaded : Ts... { using Ts::operator()...; };
+template<typename... Ts> overloaded(Ts...) -> overloaded<Ts...>;
+
+} // namespace detail
+
 FLUX_EXPORT
 template <typename Seq, typename Func, typename Init>
 concept foldable =


### PR DESCRIPTION
Defines `variadic_checked_mul` that requires at least 2 parameters, plus the variadic ones